### PR TITLE
Add "player-particles" flag to replace allow/disallow regions. (Fixes #56)

### DIFF
--- a/src/main/java/dev/esophose/playerparticles/PlayerParticles.java
+++ b/src/main/java/dev/esophose/playerparticles/PlayerParticles.java
@@ -9,6 +9,7 @@ package dev.esophose.playerparticles;
 import dev.esophose.playerparticles.gui.hook.PlayerChatHook;
 import dev.esophose.playerparticles.hook.ParticlePlaceholderExpansion;
 import dev.esophose.playerparticles.hook.PlaceholderAPIHook;
+import dev.esophose.playerparticles.hook.WorldGuardHook;
 import dev.esophose.playerparticles.manager.CommandManager;
 import dev.esophose.playerparticles.manager.ConfigurationManager;
 import dev.esophose.playerparticles.manager.ConfigurationManager.Setting;
@@ -90,6 +91,11 @@ public class PlayerParticles extends JavaPlugin {
         this.managers.clear();
     }
 
+    @Override
+    public void onLoad() {
+        WorldGuardHook.initialize();
+    }
+    
     /**
      * Gets a manager instance
      *

--- a/src/main/java/dev/esophose/playerparticles/hook/WorldGuardHook.java
+++ b/src/main/java/dev/esophose/playerparticles/hook/WorldGuardHook.java
@@ -1,30 +1,40 @@
 package dev.esophose.playerparticles.hook;
 
+import java.util.*;
+
 import dev.esophose.playerparticles.manager.ConfigurationManager.Setting;
-import java.util.List;
-import java.util.Set;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.codemc.worldguardwrapper.WorldGuardWrapper;
+import org.codemc.worldguardwrapper.flag.IWrappedFlag;
+import org.codemc.worldguardwrapper.flag.WrappedState;
 import org.codemc.worldguardwrapper.region.IWrappedRegion;
 
 public class WorldGuardHook {
 
-    private static Boolean enabled;
     private static WorldGuardWrapper worldGuardWrapper;
+    private static IWrappedFlag<WrappedState> flagPlayerParticles;
 
+    /**
+     * Initializes the WorldGuard hook.
+     * Must be called during onLoad, or else WorldGuard prevents flag registration.
+     */
+    public static void initialize() {
+        if (Bukkit.getPluginManager().getPlugin("WorldGuard") == null) {
+            return; // Unsupported
+        }
+        
+        worldGuardWrapper = WorldGuardWrapper.getInstance();
+
+        flagPlayerParticles = worldGuardWrapper.registerFlag("player-particles", WrappedState.class, WrappedState.ALLOW).get();
+    }
+    
     /**
      * @return true if WorldGuard is enabled, otherwise false
      */
     public static boolean enabled() {
-        if (enabled != null)
-            return enabled;
-        
-        enabled = Bukkit.getPluginManager().getPlugin("WorldGuard") != null;
-        if (enabled)
-            worldGuardWrapper = WorldGuardWrapper.getInstance();
+        return worldGuardWrapper != null;
 
-        return enabled;
     }
 
     /**
@@ -39,9 +49,24 @@ public class WorldGuardHook {
 
         Set<IWrappedRegion> regions = worldGuardWrapper.getRegions(location);
 
+        // Get the "player-particles" flag.
+        // This will use the region priority to determine which one takes precedence.
+        Optional<WrappedState> playerParticles = regions
+                .stream()
+                .sorted(Comparator.comparingInt(IWrappedRegion::getPriority))
+                .map(region -> region.getFlag(flagPlayerParticles))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+
+        if (playerParticles.isPresent())
+            return playerParticles.get() == WrappedState.ALLOW;
+
+        // Legacy blocking by region name.
         List<String> disallowedRegionIds = Setting.WORLDGUARD_DISALLOWED_REGIONS.getStringList();
-        if (regions.stream().map(IWrappedRegion::getId).anyMatch(disallowedRegionIds::contains))
+        if (regions.stream().map(IWrappedRegion::getId).anyMatch(disallowedRegionIds::contains)) {
             return false;
+        }
 
         if (Setting.WORLDGUARD_USE_ALLOWED_REGIONS.getBoolean()) {
             List<String> allowedRegionIds = Setting.WORLDGUARD_ALLOWED_REGIONS.getStringList();

--- a/src/main/java/dev/esophose/playerparticles/manager/ConfigurationManager.java
+++ b/src/main/java/dev/esophose/playerparticles/manager/ConfigurationManager.java
@@ -273,7 +273,7 @@ public class ConfigurationManager extends Manager {
             this.configuration.save();
         
         // Legacy nag: WorldGuard Regions
-        if (!isDefault(Setting.WORLDGUARD_ALLOWED_REGIONS) || !isDefault(Setting.WORLDGUARD_DISALLOWED_REGIONS)) {
+        if (!isDefault(Setting.WORLDGUARD_ALLOWED_REGIONS, false) || !isDefault(Setting.WORLDGUARD_DISALLOWED_REGIONS, false)) {
             Arrays.asList(
                     "It looks like you're using the 'allowed-regions' or 'disallowed-regions' settings.",
                     "These settings are deprecated from PlayerParticles, and will be removed in a future update.",
@@ -281,9 +281,18 @@ public class ConfigurationManager extends Manager {
             ).forEach(PlayerParticles.getInstance().getLogger()::warning);
         }
     }
-    
-    private boolean isDefault(Setting setting) {
+
+    /**
+     * Checks if a setting is the default value.
+     *
+     * @param setting        The setting to check.
+     * @param strictOrdering If true, compares lists with strict ordering.
+     * @return True if the setting is default.
+     */
+    private boolean isDefault(Setting setting, boolean strictOrdering) {
         if (setting.defaultValue instanceof List) {
+            if (strictOrdering) return setting.defaultValue.equals(setting.value);
+            
             HashSet<String> currentSet = new HashSet<>(setting.getStringList());
             Set<String> defaultSet = ((List<?>) setting.defaultValue).stream()
                     .map(Object::toString)

--- a/src/main/java/dev/esophose/playerparticles/manager/ConfigurationManager.java
+++ b/src/main/java/dev/esophose/playerparticles/manager/ConfigurationManager.java
@@ -7,8 +7,10 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bukkit.Material;
@@ -59,8 +61,8 @@ public class ConfigurationManager extends Manager {
 
         WORLDGUARD_SETTINGS("worldguard-settings", null, "Settings for WorldGuard", "If WorldGuard is not installed, these settings will do nothing"),
         WORLDGUARD_USE_ALLOWED_REGIONS("worldguard-settings.use-allowed-regions", false, "If true, particles will only be able to spawn if they are in an allowed region and not a disallowed region", "If false, particles will be able to spawn as long as they are not in a disallowed region"),
-        WORLDGUARD_ALLOWED_REGIONS("worldguard-settings.allowed-regions", Arrays.asList("example_region_1", "example_region_2"), "Regions that particles will be allowed to spawn in"),
-        WORLDGUARD_DISALLOWED_REGIONS("worldguard-settings.disallowed-regions", Arrays.asList("example_region_3", "example_region_4"), "Regions that particles will be blocked from spawning in", "This overrides allowed regions if they overlap"),
+        WORLDGUARD_ALLOWED_REGIONS("worldguard-settings.allowed-regions", Arrays.asList("example_region_1", "example_region_2"), "Regions that particles will be allowed to spawn in", "WARNING: This setting is deprecated in favor of region flags, and will be removed in a future update."),
+        WORLDGUARD_DISALLOWED_REGIONS("worldguard-settings.disallowed-regions", Arrays.asList("example_region_3", "example_region_4"), "Regions that particles will be blocked from spawning in", "This overrides allowed regions if they overlap", "WARNING: This setting is deprecated in favor of region flags, and will be removed in a future update."),
         WORLDGUARD_CHECK_INTERVAL("worldguard-settings.check-interval", 10, "How often to check if a player is in a region that allows spawning particles", "Measured in ticks"),
         WORLDGUARD_ENABLE_BYPASS_PERMISSION("worldguard-settings.enable-bypass-permission", false, "If true, the permission playerparticles.worldguard.bypass will allow", "the player to bypass the region requirements"),
 
@@ -269,6 +271,28 @@ public class ConfigurationManager extends Manager {
 
         if (changed)
             this.configuration.save();
+        
+        // Legacy nag: WorldGuard Regions
+        if (!isDefault(Setting.WORLDGUARD_ALLOWED_REGIONS) || !isDefault(Setting.WORLDGUARD_DISALLOWED_REGIONS)) {
+            Arrays.asList(
+                    "It looks like you're using the 'allowed-regions' or 'disallowed-regions' settings.",
+                    "These settings are deprecated from PlayerParticles, and will be removed in a future update.",
+                    "As an alternative, consider using the newer and more flexible 'player-particles' WorldGuard region flag."
+            ).forEach(PlayerParticles.getInstance().getLogger()::warning);
+        }
+    }
+    
+    private boolean isDefault(Setting setting) {
+        if (setting.defaultValue instanceof List) {
+            HashSet<String> currentSet = new HashSet<>(setting.getStringList());
+            Set<String> defaultSet = ((List<?>) setting.defaultValue).stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toSet());
+            
+            return defaultSet.equals(currentSet);
+        }
+        
+        return setting.defaultValue.equals(setting.value);
     }
 
     @Override


### PR DESCRIPTION
This pull request gives PlayerParticles the ability to register register a "player-particles" WorldGuard flag.

This flag works exactly like the existing allowed/disallowed region settings, and is intended to replace it eventually.
With the current implementation, the flag takes precedence over the old settings.

I opted against migrating the old settings, and instead printed a nag to the console if it detects they were changed.
My reason for this is that automatic migration would've caused issues if allow/disallow regions with the same name were being used across different (potentially unloaded) worlds.